### PR TITLE
Add flag to ignore the MigrationHistory table from the naming conventions

### DIFF
--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +32,25 @@ public class NameRewritingConventionTest
         var entityType = BuildEntityType(b => b.Entity<SampleEntity>());
         Assert.Equal("sample_entity_id", entityType.FindProperty(nameof(SampleEntity.SampleEntityId))!
             .GetColumnName(StoreObjectIdentifier.Create(entityType, StoreObjectType.Table)!.Value));
+    }
+
+    [Theory]
+    [InlineData(true, "__EFMigrationsHistory", "MigrationId", "ProductVersion")]
+    [InlineData(false, "__EFMigrationsHistory", "migration_id", "product_version")]
+    public void ColumnInMigrationTable(bool ignoreMigrationTable, string tableName, string migrationIdName, string productVersionName)
+    {
+        var entityType = BuildEntityType(b => b.Entity<HistoryRow>(e => {
+            e.ToTable("__EFMigrationsHistory");
+            e.HasKey(h => h.MigrationId);
+            e.Property(h => h.MigrationId).HasMaxLength(150);
+            e.Property(h => h.ProductVersion).HasMaxLength(32).IsRequired();
+        }), ignoreMigrationTable: ignoreMigrationTable);
+
+        Assert.Equal(tableName, entityType.GetTableName());
+        Assert.Equal(migrationIdName, entityType.FindProperty(nameof(HistoryRow.MigrationId))
+           .GetColumnName(StoreObjectIdentifier.Create(entityType, StoreObjectType.Table)!.Value));
+        Assert.Equal(productVersionName, entityType.FindProperty(nameof(HistoryRow.ProductVersion))
+           .GetColumnName(StoreObjectIdentifier.Create(entityType, StoreObjectType.Table)!.Value));
     }
 
     [Fact]
@@ -787,10 +808,10 @@ public class NameRewritingConventionTest
         Assert.Equal("fk_card_board_board_id", entityType.GetForeignKeys().Single().GetConstraintName());
     }
 
-    private static IEntityType BuildEntityType(Action<ModelBuilder> builderAction, CultureInfo? culture = null)
-        => BuildModel(builderAction, culture).GetEntityTypes().Single();
+    private IEntityType BuildEntityType(Action<ModelBuilder> builderAction, CultureInfo? culture = null, bool ignoreMigrationTable = false)
+        => BuildModel(builderAction, culture, ignoreMigrationTable).GetEntityTypes().Single();
 
-    private static IModel BuildModel(Action<ModelBuilder> builderAction, CultureInfo? culture = null)
+    private IModel BuildModel(Action<ModelBuilder> builderAction, CultureInfo? culture = null, bool ignoreMigrationTable = false)
     {
         var services = SqlServerTestHelpers
             .Instance
@@ -804,7 +825,7 @@ public class NameRewritingConventionTest
 
         var optionsBuilder = new DbContextOptionsBuilder();
         SqlServerTestHelpers.Instance.UseProviderOptions(optionsBuilder);
-        optionsBuilder.UseSnakeCaseNamingConvention(culture);
+        optionsBuilder.UseSnakeCaseNamingConvention(culture, ignoreMigrationTable);
         var plugin = new NamingConventionSetPlugin(dependencies, optionsBuilder.Options);
         plugin.ModifyConventions(conventionSet);
 

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -28,10 +28,12 @@ public class NameRewritingConvention :
 
     private readonly Dictionary<Type, string> _sets;
     private readonly INameRewriter _namingNameRewriter;
+    private readonly bool _ignoreMigrationTable;
 
-    public NameRewritingConvention(ProviderConventionSetBuilderDependencies dependencies, INameRewriter nameRewriter)
+    public NameRewritingConvention(ProviderConventionSetBuilderDependencies dependencies, INameRewriter nameRewriter, bool ignoreMigrationTable = false)
     {
         _namingNameRewriter = nameRewriter;
+        _ignoreMigrationTable = ignoreMigrationTable;
 
         // Copied from TableNameFromDbSetConvention
         _sets = [];
@@ -57,6 +59,7 @@ public class NameRewritingConvention :
                 _sets.Remove(type);
             }
         }
+
     }
 
     public virtual void ProcessEntityTypeAdded(
@@ -555,6 +558,11 @@ public class NameRewritingConvention :
 
         // Remove any previous setting of the column name we may have done, so we can get the default recalculated below.
         property.Builder.HasNoAnnotation(RelationalAnnotationNames.ColumnName);
+
+        if (_ignoreMigrationTable && structuralType.ClrType.FullName == "Microsoft.EntityFrameworkCore.Migrations.HistoryRow")
+        {
+            return;
+        }
 
         // TODO: The following is a temporary hack. We should probably just always set the relational override below,
         // but https://github.com/dotnet/efcore/pull/23834

--- a/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
@@ -26,6 +26,7 @@ public class NamingConventionSetPlugin : IConventionSetPlugin
             new NamingConventionsOptionsExtension().WithoutNaming();
         var namingStyle = extension.NamingConvention;
         var culture = extension.Culture;
+        var ignoreMigrationTable = extension.IgnoreMigrationTable;
         if (namingStyle == NamingConvention.None)
         {
             return conventionSet;
@@ -39,7 +40,7 @@ public class NamingConventionSetPlugin : IConventionSetPlugin
             NamingConvention.UpperCase => new UpperCaseNameRewriter(culture ?? CultureInfo.InvariantCulture),
             NamingConvention.UpperSnakeCase => new UpperSnakeCaseNameRewriter(culture ?? CultureInfo.InvariantCulture),
             _ => throw new ArgumentOutOfRangeException("Unhandled enum value: " + namingStyle)
-        });
+        }, ignoreMigrationTable);
 
         conventionSet.EntityTypeAddedConventions.Add(convention);
         conventionSet.EntityTypeAnnotationChangedConventions.Add(convention);

--- a/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
@@ -12,12 +12,14 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
     private DbContextOptionsExtensionInfo? _info;
     private NamingConvention _namingConvention;
     private CultureInfo? _culture;
+    private bool _ignoreMigrationTable;
 
     public NamingConventionsOptionsExtension() {}
     protected NamingConventionsOptionsExtension(NamingConventionsOptionsExtension copyFrom)
     {
         _namingConvention = copyFrom._namingConvention;
         _culture = copyFrom._culture;
+        _ignoreMigrationTable = copyFrom._ignoreMigrationTable;
     }
 
     public virtual DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
@@ -26,6 +28,7 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
 
     internal virtual NamingConvention NamingConvention => _namingConvention;
     internal virtual CultureInfo? Culture => _culture;
+    internal virtual bool IgnoreMigrationTable => _ignoreMigrationTable;
 
     public virtual NamingConventionsOptionsExtension WithoutNaming()
     {
@@ -34,43 +37,48 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
         return clone;
     }
 
-    public virtual NamingConventionsOptionsExtension WithSnakeCaseNamingConvention(CultureInfo? culture = null)
+    public virtual NamingConventionsOptionsExtension WithSnakeCaseNamingConvention(CultureInfo? culture = null, bool ignoreMigrationTable = false)
     {
         var clone = Clone();
         clone._namingConvention = NamingConvention.SnakeCase;
         clone._culture = culture;
+        clone._ignoreMigrationTable = ignoreMigrationTable;
         return clone;
     }
 
-    public virtual NamingConventionsOptionsExtension WithLowerCaseNamingConvention(CultureInfo? culture = null)
+    public virtual NamingConventionsOptionsExtension WithLowerCaseNamingConvention(CultureInfo? culture = null, bool ignoreMigrationTable = false)
     {
         var clone = Clone();
         clone._namingConvention = NamingConvention.LowerCase;
         clone._culture = culture;
+        clone._ignoreMigrationTable = ignoreMigrationTable;
         return clone;
     }
 
-    public virtual NamingConventionsOptionsExtension WithUpperCaseNamingConvention(CultureInfo? culture = null)
+    public virtual NamingConventionsOptionsExtension WithUpperCaseNamingConvention(CultureInfo? culture = null, bool ignoreMigrationTable = false)
     {
         var clone = Clone();
         clone._namingConvention = NamingConvention.UpperCase;
         clone._culture = culture;
+        clone._ignoreMigrationTable = ignoreMigrationTable;
         return clone;
     }
 
-    public virtual NamingConventionsOptionsExtension WithUpperSnakeCaseNamingConvention(CultureInfo? culture = null)
+    public virtual NamingConventionsOptionsExtension WithUpperSnakeCaseNamingConvention(CultureInfo? culture = null, bool ignoreMigrationTable = false)
     {
         var clone = Clone();
         clone._namingConvention = NamingConvention.UpperSnakeCase;
         clone._culture = culture;
+        clone._ignoreMigrationTable = ignoreMigrationTable;
         return clone;
     }
 
-    public virtual NamingConventionsOptionsExtension WithCamelCaseNamingConvention(CultureInfo? culture = null)
+    public virtual NamingConventionsOptionsExtension WithCamelCaseNamingConvention(CultureInfo? culture = null, bool ignoreMigrationTable = false)
     {
         var clone = Clone();
         clone._namingConvention = NamingConvention.CamelCase;
         clone._culture = culture;
+        clone._ignoreMigrationTable = ignoreMigrationTable;
         return clone;
     }
 
@@ -109,6 +117,12 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
                         _ => throw new ArgumentOutOfRangeException("Unhandled enum value: " + Extension._namingConvention)
                     });
 
+                    if (Extension._ignoreMigrationTable)
+                    {
+                        builder
+                            .Append(" ignoring the migrations table");
+                    }
+
                     if (Extension._culture is null)
                     {
                         builder
@@ -128,6 +142,7 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
         {
             var hashCode = Extension._namingConvention.GetHashCode();
             hashCode = (hashCode * 3) ^ (Extension._culture?.GetHashCode() ?? 0);
+            hashCode = (hashCode * 7) ^ (Extension._ignoreMigrationTable.GetHashCode());
             return hashCode;
         }
 
@@ -138,6 +153,10 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
         {
             debugInfo["Naming:UseNamingConvention"]
                 = Extension._namingConvention.GetHashCode().ToString(CultureInfo.InvariantCulture);
+
+            debugInfo["Naming:IgnoreMigrationTable"]
+                    = Extension._ignoreMigrationTable.GetHashCode().ToString(CultureInfo.InvariantCulture);
+
             if (Extension._culture != null)
             {
                 debugInfo["Naming:Culture"]

--- a/EFCore.NamingConventions/NamingConventionsExtensions.cs
+++ b/EFCore.NamingConventions/NamingConventionsExtensions.cs
@@ -9,14 +9,15 @@ namespace Microsoft.EntityFrameworkCore;
 public static class NamingConventionsExtensions
 {
     public static DbContextOptionsBuilder UseSnakeCaseNamingConvention(
-        this DbContextOptionsBuilder optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
     {
         Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 
         var extension = (optionsBuilder.Options.FindExtension<NamingConventionsOptionsExtension>()
                 ?? new NamingConventionsOptionsExtension())
-            .WithSnakeCaseNamingConvention(culture);
+            .WithSnakeCaseNamingConvention(culture, ignoreMigrationTable);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
@@ -24,19 +25,20 @@ public static class NamingConventionsExtensions
     }
 
     public static DbContextOptionsBuilder<TContext> UseSnakeCaseNamingConvention<TContext>(
-        this DbContextOptionsBuilder<TContext> optionsBuilder , CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder , CultureInfo? culture = null, bool ignoreMigrationTable = false)
         where TContext : DbContext
-        => (DbContextOptionsBuilder<TContext>)UseSnakeCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
+        => (DbContextOptionsBuilder<TContext>)UseSnakeCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture, ignoreMigrationTable);
 
     public static DbContextOptionsBuilder UseLowerCaseNamingConvention(
-        this DbContextOptionsBuilder optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
     {
         Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 
         var extension = (optionsBuilder.Options.FindExtension<NamingConventionsOptionsExtension>()
                 ?? new NamingConventionsOptionsExtension())
-            .WithLowerCaseNamingConvention(culture);
+            .WithLowerCaseNamingConvention(culture, ignoreMigrationTable);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
@@ -44,20 +46,22 @@ public static class NamingConventionsExtensions
     }
 
     public static DbContextOptionsBuilder<TContext> UseLowerCaseNamingConvention<TContext>(
-        this DbContextOptionsBuilder<TContext> optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
         where TContext : DbContext
-        => (DbContextOptionsBuilder<TContext>)UseLowerCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder ,culture);
+        => (DbContextOptionsBuilder<TContext>)UseLowerCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder ,culture, ignoreMigrationTable);
 
     public static DbContextOptionsBuilder UseUpperCaseNamingConvention(
-        this DbContextOptionsBuilder optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
     {
         Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 
         var extension = (optionsBuilder.Options.FindExtension<NamingConventionsOptionsExtension>()
                 ?? new NamingConventionsOptionsExtension())
-            .WithUpperCaseNamingConvention(culture);
+            .WithUpperCaseNamingConvention(culture, ignoreMigrationTable);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
@@ -65,20 +69,22 @@ public static class NamingConventionsExtensions
     }
 
     public static DbContextOptionsBuilder<TContext> UseUpperCaseNamingConvention<TContext>(
-        this DbContextOptionsBuilder<TContext> optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
         where TContext : DbContext
-        => (DbContextOptionsBuilder<TContext>)UseUpperCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
+        => (DbContextOptionsBuilder<TContext>)UseUpperCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture, ignoreMigrationTable);
 
     public static DbContextOptionsBuilder UseUpperSnakeCaseNamingConvention(
-        this DbContextOptionsBuilder optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
     {
         Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 
         var extension = (optionsBuilder.Options.FindExtension<NamingConventionsOptionsExtension>()
                 ?? new NamingConventionsOptionsExtension())
-            .WithUpperSnakeCaseNamingConvention(culture);
+            .WithUpperSnakeCaseNamingConvention(culture, ignoreMigrationTable);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
@@ -86,20 +92,22 @@ public static class NamingConventionsExtensions
     }
 
     public static DbContextOptionsBuilder<TContext> UseUpperSnakeCaseNamingConvention<TContext>(
-        this DbContextOptionsBuilder<TContext> optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
         where TContext : DbContext
-        => (DbContextOptionsBuilder<TContext>)UseUpperSnakeCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
+        => (DbContextOptionsBuilder<TContext>)UseUpperSnakeCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture, ignoreMigrationTable);
 
     public static DbContextOptionsBuilder UseCamelCaseNamingConvention(
-        this DbContextOptionsBuilder optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
     {
         Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 
         var extension = (optionsBuilder.Options.FindExtension<NamingConventionsOptionsExtension>()
                 ?? new NamingConventionsOptionsExtension())
-            .WithCamelCaseNamingConvention(culture);
+            .WithCamelCaseNamingConvention(culture, ignoreMigrationTable);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
@@ -107,8 +115,9 @@ public static class NamingConventionsExtensions
     }
 
     public static DbContextOptionsBuilder<TContext> UseCamelCaseNamingConvention<TContext>(
-        this DbContextOptionsBuilder<TContext> optionsBuilder,
-        CultureInfo? culture = null)
+        [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+        CultureInfo? culture = null,
+        bool ignoreMigrationTable = false)
         where TContext : DbContext
-        => (DbContextOptionsBuilder<TContext>)UseCamelCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
+        => (DbContextOptionsBuilder<TContext>)UseCamelCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture, ignoreMigrationTable);
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ SELECT c.id, c.full_name
         WHERE c.full_name = 'John Doe';
 ```
 
+## Ignoring the Migration Table `__EFMigrationsHistory`
+
+To make migrations of existing databases more robust one might want to leave the migrations table out of the naming conventions.
+
+```c#
+protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    => optionsBuilder
+        .UseNpgsql(...)
+        .UseSnakeCaseNamingConvention(ignoreMigrationTable: true);
+```
+
 ## Supported naming conventions
 
 * UseSnakeCaseNamingConvention: `FullName` becomes `full_name`


### PR DESCRIPTION
I put some tests in for now that should test the column names. (And the table name, but that doesn't change).

Not sure if this is the right way to go with the FullName test against a string, but it seems quite unlikely to have a name collision there.

Closes #1