### PR TITLE
Support efcore 6.0 preview 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.100-preview.3.21202.5'
 
       - name: Test
         run: dotnet test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <EFCoreVersion>5.0.5</EFCoreVersion>
-    <MicrosoftExtensionsVersion>5.0.0</MicrosoftExtensionsVersion>
+    <EFCoreVersion>6.0.0-preview.3.21201.2</EFCoreVersion>
+    <MicrosoftExtensionsVersion>6.0.0-preview.3.21201.4</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.NamingConventions.Test/EFCore.NamingConventions.Test.csproj
+++ b/EFCore.NamingConventions.Test/EFCore.NamingConventions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.NamingConventions/EFCore.NamingConventions.csproj
+++ b/EFCore.NamingConventions/EFCore.NamingConventions.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <VersionPrefix>5.0.2</VersionPrefix>
+    <TargetFramework>net6.0</TargetFramework>
+    <VersionPrefix>6.0.0-preview.3</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../EFCore.NamingConventions.snk</AssemblyOriginatorKeyFile>

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -235,16 +235,10 @@ namespace EFCore.NamingConventions.Internal
 
             // TODO: The following is a temporary hack. We should probably just always set the relational override below,
             // but https://github.com/dotnet/efcore/pull/23834
-#pragma warning disable 618
-            var table = StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table);
-            var annotation = property.FindAnnotation(RelationalAnnotationNames.ColumnName);
-            var columnName = annotation == null
-                ? table == null
+            var baseColumnName = StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table) is { } tableIdentifier
                     ? property.GetDefaultColumnBaseName()
-                    : property.GetDefaultColumnName(table.Value)
-                : (string)annotation.Value;
-            propertyBuilder.HasColumnName(_namingNameRewriter.RewriteName(columnName));
-#pragma warning restore 618
+                    : property.GetDefaultColumnName(tableIdentifier);
+            propertyBuilder.HasColumnName(_namingNameRewriter.RewriteName(baseColumnName));
 
             foreach (var storeObjectType in _storeObjectTypes)
             {

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -236,8 +236,8 @@ namespace EFCore.NamingConventions.Internal
             // TODO: The following is a temporary hack. We should probably just always set the relational override below,
             // but https://github.com/dotnet/efcore/pull/23834
             var baseColumnName = StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table) is { } tableIdentifier
-                    ? property.GetDefaultColumnBaseName()
-                    : property.GetDefaultColumnName(tableIdentifier);
+                ? property.GetDefaultColumnName(tableIdentifier)
+                : property.GetDefaultColumnBaseName();
             propertyBuilder.HasColumnName(_namingNameRewriter.RewriteName(baseColumnName));
 
             foreach (var storeObjectType in _storeObjectTypes)


### PR DESCRIPTION
Fixes https://github.com/efcore/EFCore.NamingConventions/issues/74
`GetTableName` works fine at runtime if we explicitly target preview 3 version of efcore.
However, `GetColumnName` without parameters has been removed from public API. I’ve just reimplemented it.