### PR TITLE
Upgrade to RC1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: '6.0.100-preview.3.21202.5'
+          dotnet-version: '6.0.0-rc.1.21451.13'
 
       - name: Test
         run: dotnet test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: '6.0.0-rc.1.21451.13'
+          dotnet-version: '6.0.100-rc.1.21463.6'
 
       - name: Test
         run: dotnet test

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <EFCoreVersion>6.0.0-preview.3.21201.2</EFCoreVersion>
-    <MicrosoftExtensionsVersion>6.0.0-preview.3.21201.4</MicrosoftExtensionsVersion>
+    <EFCoreVersion>6.0.0-rc.1.21452.10</EFCoreVersion>
+    <MicrosoftExtensionsVersion>6.0.0-rc.1.21451.13</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -9,7 +9,9 @@ using System.Linq;
 using EFCore.NamingConventions.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace EFCore.NamingConventions.Test
@@ -407,7 +409,11 @@ namespace EFCore.NamingConventions.Test
 
         private IModel BuildModel(Action<ModelBuilder> builderAction, CultureInfo culture = null)
         {
-            var conventionSet = SqliteTestHelpers.Instance.CreateConventionSetBuilder().CreateConventionSet();
+            var conventionSet = SqliteTestHelpers
+                .Instance
+                .CreateContextServices()
+                .GetRequiredService<IConventionSetBuilder>()
+                .CreateConventionSet();
 
             var optionsBuilder = new DbContextOptionsBuilder();
             SqliteTestHelpers.Instance.UseProviderOptions(optionsBuilder);

--- a/EFCore.NamingConventions/EFCore.NamingConventions.csproj
+++ b/EFCore.NamingConventions/EFCore.NamingConventions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>6.0.0-preview.3</VersionPrefix>
+    <VersionPrefix>6.0.0-rc.1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../EFCore.NamingConventions.snk</AssemblyOriginatorKeyFile>

--- a/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
@@ -124,12 +124,15 @@ namespace EFCore.NamingConventions.Internal
                 }
             }
 
-            public override long GetServiceProviderHashCode()
+            public override int GetServiceProviderHashCode()
             {
                 var hashCode = Extension._namingConvention.GetHashCode();
                 hashCode = (hashCode * 3) ^ (Extension._culture?.GetHashCode() ?? 0);
                 return hashCode;
             }
+
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+                => true;
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
             {


### PR DESCRIPTION
Changes made:
- Upgrade package versions
- Upgrade C# version (there was an error because of global using statements without the upgrade)
- Upgrade dotnet version in build workflow
- Updated version prefix to `6.0.0-rc.1`
- Replaces the invocation of the method `CreateConventionSetBuilder()` since it appears it has been removed
- Changed the return type of `GetServiceProviderHashCode` method from `long` to `int`
- Created implementation of `ShouldUseSameServiceProvider` method to always return `true`

All tests are passing.