### PR TITLE
Add support for IForeignKeyPropertiesChangedConvention

### DIFF
--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -14,6 +15,7 @@ public class NameRewritingConvention :
     IForeignKeyOwnershipChangedConvention,
     IKeyAddedConvention,
     IForeignKeyAddedConvention,
+    IForeignKeyPropertiesChangedConvention,
     IIndexAddedConvention,
     IEntityTypeBaseTypeChangedConvention,
     IModelFinalizingConvention
@@ -196,6 +198,13 @@ public class NameRewritingConvention :
     public void ProcessForeignKeyAdded(
         IConventionForeignKeyBuilder relationshipBuilder,
         IConventionContext<IConventionForeignKeyBuilder> context)
+        => relationshipBuilder.HasConstraintName(_namingNameRewriter.RewriteName(relationshipBuilder.Metadata.GetDefaultName()));
+
+    public void ProcessForeignKeyPropertiesChanged(
+        IConventionForeignKeyBuilder relationshipBuilder,
+        IReadOnlyList<IConventionProperty> oldDependentProperties,
+        IConventionKey oldPrincipalKey,
+        IConventionContext<IReadOnlyList<IConventionProperty>> context)
         => relationshipBuilder.HasConstraintName(_namingNameRewriter.RewriteName(relationshipBuilder.Metadata.GetDefaultName()));
 
     public void ProcessKeyAdded(IConventionKeyBuilder keyBuilder, IConventionContext<IConventionKeyBuilder> context)

--- a/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
@@ -38,6 +38,7 @@ public class NamingConventionSetPlugin : IConventionSetPlugin
         conventionSet.ForeignKeyOwnershipChangedConventions.Add(convention);
         conventionSet.KeyAddedConventions.Add(convention);
         conventionSet.ForeignKeyAddedConventions.Add(convention);
+        conventionSet.ForeignKeyPropertiesChangedConventions.Add(convention);
         conventionSet.IndexAddedConventions.Add(convention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(convention);
         conventionSet.ModelFinalizingConventions.Add(convention);


### PR DESCRIPTION
Added support for IForeignKeyPropertiesChangedConvention. 

Since EF Core 6.x.x the NameRewritingConvention is no longer triggered when the principal key is changed. 

This PR should ensure, that the name of the foreign key constraint is kept in sync with changes in the principal key.

See #148 for details.