### PR TITLE
fix "Regression in 7.0.2: TPH table names are not being rewritten" fix #184

### DIFF
--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -235,6 +235,37 @@ public class NameRewritingConventionTest
     }
 
     [Fact]
+    public void TPH_with_abstract()
+    {
+        var model = BuildModel(b =>
+        {
+            b.Entity<AbstractParent>();
+            b.Entity<ChildOfAbstract>();
+        });
+
+        var parentEntityType = model.FindEntityType(typeof(AbstractParent))!;
+        var childEntityType = model.FindEntityType(typeof(ChildOfAbstract))!;
+
+        Assert.Equal("abstract_parent", parentEntityType.GetTableName());
+
+        Assert.Equal("abstract_parent", childEntityType.GetTableName());
+        Assert.Equal("id", childEntityType.FindProperty(nameof(AbstractParent.Id))!
+            .GetColumnName(StoreObjectIdentifier.Create(childEntityType, StoreObjectType.Table)!.Value));
+        Assert.Equal("discriminator", childEntityType.FindProperty("Discriminator")!
+            .GetColumnName(StoreObjectIdentifier.Create(childEntityType, StoreObjectType.Table)!.Value));
+        Assert.Equal("child_property", childEntityType.FindProperty(nameof(ChildOfAbstract.ChildProperty))!
+            .GetColumnName(StoreObjectIdentifier.Create(childEntityType, StoreObjectType.Table)!.Value));
+
+        var primaryKey = parentEntityType.FindPrimaryKey()!;
+        Assert.Same(primaryKey, childEntityType.FindPrimaryKey());
+
+        Assert.Equal("pk_abstract_parent", primaryKey.GetName());
+
+        var childStoreObjectIdentifier = StoreObjectIdentifier.Create(childEntityType, StoreObjectType.Table)!.Value;
+        Assert.Equal("pk_abstract_parent", primaryKey.GetName(childStoreObjectIdentifier));
+    }
+
+    [Fact]
     public void TPT_with_owned()
     {
         var model = BuildModel(b =>


### PR DESCRIPTION
fix "Regression in 7.0.2: TPH table names are not being rewritten" fix #184