### PR TITLE
Added 'FK property changed' convention and test.

### DIFF
--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -105,6 +105,14 @@ public class NameRewritingConventionTest
     }
 
     [Fact]
+    public void Foreign_key_on_key_without_setter()
+    {
+        var model = BuildModel(b => b.Entity<Board>().HasKey(e => e.Id));
+        var entityType = model.FindEntityType(typeof(Card))!;
+        Assert.Equal("fk_card_board_board_id", entityType.GetForeignKeys().Single().GetConstraintName());
+    }
+
+    [Fact]
     public void Index()
     {
         var entityType = BuildEntityType(b => b.Entity<SampleEntity>().HasIndex(s => s.SomeProperty));
@@ -612,7 +620,7 @@ public class NameRewritingConventionTest
 
     public abstract class AbstractParent
     {
-        public int Id { get; set; }
+        public int Id { get; }
         public int ParentProperty { get; set; }
     }
 
@@ -657,5 +665,19 @@ public class NameRewritingConventionTest
     public class Owned
     {
         public int OwnedProperty { get; set; }
+    }
+
+    public class Board
+    {
+        public int Id { get; }
+
+        public List<Card> Cards { get; private set; }
+    }
+
+    public class Card
+    {
+        public int Id { get; }
+
+        public Board Board { get; private set; }
     }
 }

--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -620,7 +620,7 @@ public class NameRewritingConventionTest
 
     public abstract class AbstractParent
     {
-        public int Id { get; }
+        public int Id { get; set; }
         public int ParentProperty { get; set; }
     }
 

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -14,6 +15,7 @@ public class NameRewritingConvention :
     IForeignKeyOwnershipChangedConvention,
     IKeyAddedConvention,
     IForeignKeyAddedConvention,
+    IForeignKeyPropertiesChangedConvention,
     IIndexAddedConvention,
     IEntityTypeBaseTypeChangedConvention,
     IModelFinalizingConvention
@@ -215,6 +217,18 @@ public class NameRewritingConvention :
     public void ProcessForeignKeyAdded(
         IConventionForeignKeyBuilder relationshipBuilder,
         IConventionContext<IConventionForeignKeyBuilder> context)
+    {
+        if (relationshipBuilder.Metadata.GetDefaultName() is { } constraintName)
+        {
+            relationshipBuilder.HasConstraintName(_namingNameRewriter.RewriteName(constraintName));
+        }
+    }
+
+    public void ProcessForeignKeyPropertiesChanged(
+        IConventionForeignKeyBuilder relationshipBuilder,
+        IReadOnlyList<IConventionProperty> oldDependentProperties,
+        IConventionKey oldPrincipalKey,
+        IConventionContext<IReadOnlyList<IConventionProperty>> context)
     {
         if (relationshipBuilder.Metadata.GetDefaultName() is { } constraintName)
         {

--- a/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
@@ -38,6 +38,7 @@ public class NamingConventionSetPlugin : IConventionSetPlugin
         conventionSet.ForeignKeyOwnershipChangedConventions.Add(convention);
         conventionSet.KeyAddedConventions.Add(convention);
         conventionSet.ForeignKeyAddedConventions.Add(convention);
+        conventionSet.ForeignKeyPropertiesChangedConventions.Add(convention);
         conventionSet.IndexAddedConventions.Add(convention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(convention);
         conventionSet.ModelFinalizingConventions.Add(convention);


### PR DESCRIPTION
Implementation of the **IForeignKeyPropertiesChangedConvention**'.

PS.:
The test implemented covers what triggered the issue for me.

EF core does not automatically maps properties without setters. https://github.com/dotnet/efcore/issues/10844#issuecomment-362338017

In case you define an ID without a setter, EF will map it as "Keyless" and add "temp" to the FK constraint names.

Once you define an ID manually, the constraints name are never corrected since **ForeignKeyPropertiesChangedConventions** is not implemented.

Fixes issues: https://github.com/efcore/EFCore.NamingConventions/issues/148, https://github.com/efcore/EFCore.NamingConventions/issues/198

Pre-existing PR: https://github.com/efcore/EFCore.NamingConventions/pull/149

![image](https://github.com/efcore/EFCore.NamingConventions/assets/29243277/4fad15d8-d080-4820-8f91-03a232257518)
