### PR TITLE
Honor explicit index name

### DIFF
--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -117,10 +117,26 @@ public class NameRewritingConventionTest
     }
 
     [Fact]
+    public void Foreign_key_with_explicit_constraint_name()
+    {
+        var model = BuildModel(b => b.Entity<Blog>().HasMany(p => p.Posts)
+            .WithOne(p => p.Blog).HasForeignKey(p => p.BlogId).HasConstraintName("MY_FK_CONSTRAINT"));
+        var entityType = model.FindEntityType(typeof(Post))!;
+        Assert.Equal("MY_FK_CONSTRAINT", entityType.GetForeignKeys().Single().GetConstraintName());
+    }
+
+    [Fact]
     public void Index()
     {
         var entityType = BuildEntityType(b => b.Entity<SampleEntity>().HasIndex(s => s.SomeProperty));
         Assert.Equal("ix_sample_entity_some_property", entityType.GetIndexes().Single().GetDatabaseName());
+    }
+
+    [Fact]
+    public void Index_with_explicit_name()
+    {
+        var entityType = BuildEntityType(b => b.Entity<SampleEntity>().HasIndex(s => s.SomeProperty, "MY_INDEX"));
+        Assert.Equal("MY_INDEX", entityType.GetIndexes().Single().GetDatabaseName());
     }
 
     [Fact]

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -389,7 +389,7 @@ public class NameRewritingConvention :
         IConventionIndexBuilder indexBuilder,
         IConventionContext<IConventionIndexBuilder> context)
     {
-        if (indexBuilder.Metadata.GetDefaultDatabaseName() is { } indexName)
+        if (indexBuilder.Metadata.Name is null && indexBuilder.Metadata.GetDefaultDatabaseName() is { } indexName)
         {
             indexBuilder.HasDatabaseName(_namingNameRewriter.RewriteName(indexName));
         }


### PR DESCRIPTION
When an index is created and an explicit name is provided, the name should not be rewritten. There is also a unit test to ensure that the explicit name for a foreign key is also honored.