### PR TITLE
Changed INameRewriter parameter to align with EF Core IConventionKeyBuilder.Metadata.GetName() return type

### DIFF
--- a/EFCore.NamingConventions/Internal/CamelCaseNameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/CamelCaseNameRewriter.cs
@@ -9,6 +9,6 @@ public class CamelCaseNameRewriter : INameRewriter
     public CamelCaseNameRewriter(CultureInfo culture)
         => _culture = culture;
 
-    public string RewriteName(string name)
+    public string? RewriteName(string? name)
         => string.IsNullOrEmpty(name) ? name: char.ToLower(name[0], _culture) + name.Substring(1);
 }

--- a/EFCore.NamingConventions/Internal/INameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/INameRewriter.cs
@@ -2,5 +2,5 @@ namespace EFCore.NamingConventions.Internal;
 
 public interface INameRewriter
 {
-    string RewriteName(string name);
+    string? RewriteName(string? name);
 }

--- a/EFCore.NamingConventions/Internal/LowerCaseNameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/LowerCaseNameRewriter.cs
@@ -9,6 +9,6 @@ public class LowerCaseNameRewriter : INameRewriter
     public LowerCaseNameRewriter(CultureInfo culture)
         => _culture = culture;
 
-    public string RewriteName(string name)
-        => name.ToLower(_culture);
+    public string? RewriteName(string? name)
+        => name?.ToLower(_culture);
 }

--- a/EFCore.NamingConventions/Internal/SnakeCaseNameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/SnakeCaseNameRewriter.cs
@@ -11,8 +11,11 @@ public class SnakeCaseNameRewriter : INameRewriter
     public SnakeCaseNameRewriter(CultureInfo culture)
         => _culture = culture;
 
-    public virtual string RewriteName(string name)
+    public virtual string? RewriteName(string? name)
     {
+        if (string.IsNullOrEmpty(name))
+            return name;
+
         var builder = new StringBuilder(name.Length + Math.Min(2, name.Length / 5));
         var previousCategory = default(UnicodeCategory?);
 

--- a/EFCore.NamingConventions/Internal/UpperCaseNameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/UpperCaseNameRewriter.cs
@@ -9,6 +9,6 @@ public class UpperCaseNameRewriter : INameRewriter
     public UpperCaseNameRewriter(CultureInfo culture)
         => _culture = culture;
 
-    public string RewriteName(string name)
-        => name.ToUpper(_culture);
+    public string? RewriteName(string? name)
+        => name?.ToUpper(_culture);
 }

--- a/EFCore.NamingConventions/Internal/UpperSnakeCaseNameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/UpperSnakeCaseNameRewriter.cs
@@ -9,6 +9,6 @@ public class UpperSnakeCaseNameRewriter : SnakeCaseNameRewriter
     public UpperSnakeCaseNameRewriter(CultureInfo culture) : base(culture)
         => _culture = culture;
 
-    public override string RewriteName(string name)
-        => base.RewriteName(name).ToUpper(_culture);
+    public override string? RewriteName(string? name)
+        => base.RewriteName(name)?.ToUpper(_culture);
 }


### PR DESCRIPTION
Changed INameRewriter parameter to align with EF Core IConventionKeyBuilder.Metadata.GetName() return type of `string?`.

Updated all classes that implemented INameRewriter with the updated method signatures and handled any spots where a null value could have been referenced before checking if the reference contained a value.