### PR TITLE
Upgrade to .NET 9 and entity framework 9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <EFCoreVersion>[8.0.0,9.0.0)</EFCoreVersion>
-    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
+    <EFCoreVersion>[9.0.0,10.0.0)</EFCoreVersion>
+    <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.NamingConventions.Test/EFCore.NamingConventions.Test.csproj
+++ b/EFCore.NamingConventions.Test/EFCore.NamingConventions.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.NamingConventions/EFCore.NamingConventions.csproj
+++ b/EFCore.NamingConventions/EFCore.NamingConventions.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <VersionPrefix>8.0.2</VersionPrefix>
+    <TargetFramework>net9.0</TargetFramework>
+    <VersionPrefix>9.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../EFCore.NamingConventions.snk</AssemblyOriginatorKeyFile>

--- a/EFCore.NamingConventions/EFCore.NamingConventions.csproj
+++ b/EFCore.NamingConventions/EFCore.NamingConventions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <VersionPrefix>9.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Hi.

Not sure how you handle major version upgrade but if it can help you will find here a PR bumping .NET & entity framework version to 9.

No code change seem to be required and unit tests pass