### PR TITLE
Add parameter to ignore migration history table in UseSnakeCaseNamingConvention

### DIFF
--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -27,10 +27,12 @@ public class NameRewritingConvention :
 
     private readonly IDictionary<Type, string> _sets;
     private readonly INameRewriter _namingNameRewriter;
+    private readonly bool _ignoreMigrationHistoryTable;
 
-    public NameRewritingConvention(ProviderConventionSetBuilderDependencies dependencies, INameRewriter nameRewriter)
+    public NameRewritingConvention(ProviderConventionSetBuilderDependencies dependencies, INameRewriter nameRewriter, bool ignoreMigrationHistoryTable)
     {
         _namingNameRewriter = nameRewriter;
+        _ignoreMigrationHistoryTable = ignoreMigrationHistoryTable;
 
         // Copied from TableNameFromDbSetConvention
         _sets = new Dictionary<Type, string>();
@@ -63,6 +65,11 @@ public class NameRewritingConvention :
         IConventionContext<IConventionEntityTypeBuilder> context)
     {
         var entityType = entityTypeBuilder.Metadata;
+
+        if (_ignoreMigrationHistoryTable && entityType.GetTableName() == "__EFMigrationsHistory")
+        {
+            return;
+        }
 
         // Note that the table name returned here may be the result of TableNameFromDbSetConvention which ran before us.
         if (entityType.GetTableName() is { } tableName)

--- a/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
@@ -12,12 +12,14 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
     private DbContextOptionsExtensionInfo? _info;
     private NamingConvention _namingConvention;
     private CultureInfo? _culture;
+    private bool _ignoreMigrationHistoryTable;
 
     public NamingConventionsOptionsExtension() {}
     protected NamingConventionsOptionsExtension(NamingConventionsOptionsExtension copyFrom)
     {
         _namingConvention = copyFrom._namingConvention;
         _culture = copyFrom._culture;
+        _ignoreMigrationHistoryTable = copyFrom._ignoreMigrationHistoryTable;
     }
 
     public virtual DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
@@ -26,6 +28,7 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
 
     internal virtual NamingConvention NamingConvention => _namingConvention;
     internal virtual CultureInfo? Culture => _culture;
+    internal virtual bool IgnoreMigrationHistoryTable => _ignoreMigrationHistoryTable;
 
     public virtual NamingConventionsOptionsExtension WithoutNaming()
     {
@@ -34,11 +37,12 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
         return clone;
     }
 
-    public virtual NamingConventionsOptionsExtension WithSnakeCaseNamingConvention(CultureInfo? culture = null)
+    public virtual NamingConventionsOptionsExtension WithSnakeCaseNamingConvention(CultureInfo? culture = null, bool ignoreMigrationHistoryTable = false)
     {
         var clone = Clone();
         clone._namingConvention = NamingConvention.SnakeCase;
         clone._culture = culture;
+        clone._ignoreMigrationHistoryTable = ignoreMigrationHistoryTable;
         return clone;
     }
 
@@ -117,6 +121,11 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
                             .Append(")");
                     }
 
+                    if (Extension._ignoreMigrationHistoryTable)
+                    {
+                        builder.Append(" (ignoring migration history table)");
+                    }
+
                     _logFragment = builder.ToString();
                 }
 
@@ -128,6 +137,7 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
         {
             var hashCode = Extension._namingConvention.GetHashCode();
             hashCode = (hashCode * 3) ^ (Extension._culture?.GetHashCode() ?? 0);
+            hashCode = (hashCode * 3) ^ Extension._ignoreMigrationHistoryTable.GetHashCode();
             return hashCode;
         }
 
@@ -143,6 +153,8 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
                 debugInfo["Naming:Culture"]
                     = Extension._culture.GetHashCode().ToString(CultureInfo.InvariantCulture);
             }
+            debugInfo["Naming:IgnoreMigrationHistoryTable"]
+                = Extension._ignoreMigrationHistoryTable.GetHashCode().ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/EFCore.NamingConventions/NamingConventionsExtensions.cs
+++ b/EFCore.NamingConventions/NamingConventionsExtensions.cs
@@ -10,13 +10,14 @@ public static class NamingConventionsExtensions
 {
     public static DbContextOptionsBuilder UseSnakeCaseNamingConvention(
         this DbContextOptionsBuilder optionsBuilder,
-        CultureInfo? culture = null)
+        CultureInfo? culture = null,
+        bool ignoreMigrationHistoryTable = false)
     {
         Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 
         var extension = (optionsBuilder.Options.FindExtension<NamingConventionsOptionsExtension>()
                 ?? new NamingConventionsOptionsExtension())
-            .WithSnakeCaseNamingConvention(culture);
+            .WithSnakeCaseNamingConvention(culture, ignoreMigrationHistoryTable);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
@@ -24,9 +25,9 @@ public static class NamingConventionsExtensions
     }
 
     public static DbContextOptionsBuilder<TContext> UseSnakeCaseNamingConvention<TContext>(
-        this DbContextOptionsBuilder<TContext> optionsBuilder , CultureInfo? culture = null)
+        this DbContextOptionsBuilder<TContext> optionsBuilder , CultureInfo? culture = null, bool ignoreMigrationHistoryTable = false)
         where TContext : DbContext
-        => (DbContextOptionsBuilder<TContext>)UseSnakeCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
+        => (DbContextOptionsBuilder<TContext>)UseSnakeCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture, ignoreMigrationHistoryTable);
 
     public static DbContextOptionsBuilder UseLowerCaseNamingConvention(
         this DbContextOptionsBuilder optionsBuilder,


### PR DESCRIPTION
Add a parameter `ignoreMigrationHistoryTable` to `UseSnakeCaseNamingConvention()` to ignore columns in the `__EFMigrationsHistory` table.

* Modify `UseSnakeCaseNamingConvention` method in `EFCore.NamingConventions/NamingConventionsExtensions.cs` to accept a new parameter `ignoreMigrationHistoryTable`.
* Update `NamingConventionsOptionsExtension` class in `EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs` to include the `ignoreMigrationHistoryTable` parameter.
* Add a new field `_ignoreMigrationHistoryTable` in `NameRewritingConvention` class in `EFCore.NamingConventions/Internal/NameRewritingConvention.cs` and update the constructor and `ProcessEntityTypeAdded` method to handle the new parameter.
* Add a new test method `IgnoreMigrationHistoryTable` in `EFCore.NamingConventions.Test/IntegrationTest.cs` to test the `ignoreMigrationHistoryTable` parameter of the `UseSnakeCaseNamingConvention` method.

