### PR TITLE
Add support for UseStripEntitySuffixNamingConvention: `FullNameEntity` becomes `FullName`

### DIFF
--- a/EFCore.NamingConventions.Test/NamingConventionsOptionsExtensionTest.cs
+++ b/EFCore.NamingConventions.Test/NamingConventionsOptionsExtensionTest.cs
@@ -35,6 +35,7 @@ namespace EFCore.NamingConventions.Test
             NamingConvention.CamelCase => new NamingConventionsOptionsExtension().WithCamelCaseNamingConvention(),
             NamingConvention.UpperCase => new NamingConventionsOptionsExtension().WithUpperCaseNamingConvention(),
             NamingConvention.UpperSnakeCase => new NamingConventionsOptionsExtension().WithUpperSnakeCaseNamingConvention(),
+            NamingConvention.StripEntitySuffix => new NamingConventionsOptionsExtension().WithStripEntitySuffixNamingConvention(),
             _ => throw new ArgumentOutOfRangeException($"Unhandled enum value: {convention}, NamingConventionsOptionsExtension not defined for the test")
         };
     }

--- a/EFCore.NamingConventions.Test/RewriterTest.cs
+++ b/EFCore.NamingConventions.Test/RewriterTest.cs
@@ -28,8 +28,19 @@ public class RewriterTest
 
     [Fact]
     public void Strip_entity_suffix()
-    {
-        Assert.Equal("FullName", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullNameEntity"));
-        Assert.Equal("FullName", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullName"));
-    }
+        => Assert.Equal("FullName", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullNameEntity"));
+
+    [Fact]
+    public void Strip_entity_suffix_with_incorrect_case_should_not_rename()
+        => Assert.Equal("FullNameENtiTY", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullNameENtiTY"));
+
+    [Fact]
+    public void Strip_entity_suffix_without_suffix_should_not_rename()
+        => Assert.Equal("FullName", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullName"));
+
+    [Fact]
+    public void Strip_entity_suffix_whose_name_is_identical_to_suffix_should_not_rename()
+        => Assert.Equal("Entity", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("Entity"));
+
+
 }

--- a/EFCore.NamingConventions.Test/RewriterTest.cs
+++ b/EFCore.NamingConventions.Test/RewriterTest.cs
@@ -25,4 +25,11 @@ public class RewriterTest
     [Fact]
     public void Upper_case()
         => Assert.Equal("FULLNAME", new UpperCaseNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullName"));
+
+    [Fact]
+    public void Strip_entity_suffix()
+    {
+        Assert.Equal("FullName", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullNameEntity"));
+        Assert.Equal("FullName", new StripEntitySuffixNameRewriter(CultureInfo.InvariantCulture).RewriteName("FullName"));
+    }
 }

--- a/EFCore.NamingConventions/Internal/NamingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NamingConvention.cs
@@ -7,5 +7,6 @@ public enum NamingConvention
     LowerCase,
     CamelCase,
     UpperCase,
-    UpperSnakeCase
+    UpperSnakeCase,
+    StripEntitySuffix
 }

--- a/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionSetPlugin.cs
@@ -38,6 +38,7 @@ public class NamingConventionSetPlugin : IConventionSetPlugin
             NamingConvention.CamelCase => new CamelCaseNameRewriter(culture ?? CultureInfo.InvariantCulture),
             NamingConvention.UpperCase => new UpperCaseNameRewriter(culture ?? CultureInfo.InvariantCulture),
             NamingConvention.UpperSnakeCase => new UpperSnakeCaseNameRewriter(culture ?? CultureInfo.InvariantCulture),
+            NamingConvention.StripEntitySuffix => new StripEntitySuffixNameRewriter(culture ?? CultureInfo.InvariantCulture),
             _ => throw new ArgumentOutOfRangeException("Unhandled enum value: " + namingStyle)
         });
 

--- a/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
+++ b/EFCore.NamingConventions/Internal/NamingConventionsOptionsExtension.cs
@@ -13,7 +13,7 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
     private NamingConvention _namingConvention;
     private CultureInfo? _culture;
 
-    public NamingConventionsOptionsExtension() {}
+    public NamingConventionsOptionsExtension() { }
     protected NamingConventionsOptionsExtension(NamingConventionsOptionsExtension copyFrom)
     {
         _namingConvention = copyFrom._namingConvention;
@@ -74,7 +74,15 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
         return clone;
     }
 
-    public void Validate(IDbContextOptions options) {}
+    public virtual NamingConventionsOptionsExtension WithStripEntitySuffixNamingConvention(CultureInfo? culture = null)
+    {
+        var clone = Clone();
+        clone._namingConvention = NamingConvention.StripEntitySuffix;
+        clone._culture = culture;
+        return clone;
+    }
+
+    public void Validate(IDbContextOptions options) { }
 
     public void ApplyServices(IServiceCollection services)
         => services.AddEntityFrameworkNamingConventions();
@@ -83,7 +91,7 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
     {
         private string? _logFragment;
 
-        public ExtensionInfo(IDbContextOptionsExtension extension) : base(extension) {}
+        public ExtensionInfo(IDbContextOptionsExtension extension) : base(extension) { }
 
         private new NamingConventionsOptionsExtension Extension
             => (NamingConventionsOptionsExtension)base.Extension;
@@ -106,6 +114,7 @@ public class NamingConventionsOptionsExtension : IDbContextOptionsExtension
                         NamingConvention.UpperCase => "using upper case naming",
                         NamingConvention.UpperSnakeCase => "using upper snake-case naming",
                         NamingConvention.CamelCase => "using camel-case naming",
+                        NamingConvention.StripEntitySuffix => "removing 'Entity' suffix from name if present",
                         _ => throw new ArgumentOutOfRangeException("Unhandled enum value: " + Extension._namingConvention)
                     });
 

--- a/EFCore.NamingConventions/Internal/StripEntitySuffixNameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/StripEntitySuffixNameRewriter.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+
+namespace EFCore.NamingConventions.Internal;
+
+public class StripEntitySuffixNameRewriter : INameRewriter
+{
+    private readonly CultureInfo _culture;
+    private static readonly string EntitySuffix = "Entity";
+
+    public StripEntitySuffixNameRewriter(CultureInfo culture)
+    {
+        _culture = culture;
+    }
+
+    public string RewriteName(string name)
+    {
+        string newName = name;
+        if (name.EndsWith(EntitySuffix, false, _culture))
+        {
+            newName = name.Substring(0, name.Length - EntitySuffix.Length);
+        }
+
+        return newName;
+    }
+}

--- a/EFCore.NamingConventions/Internal/StripEntitySuffixNameRewriter.cs
+++ b/EFCore.NamingConventions/Internal/StripEntitySuffixNameRewriter.cs
@@ -14,12 +14,21 @@ public class StripEntitySuffixNameRewriter : INameRewriter
 
     public string RewriteName(string name)
     {
-        string newName = name;
-        if (name.EndsWith(EntitySuffix, false, _culture))
+        // If the name has the expected suffix and
+        // the name is longer than the suffix itself, then
+        // remove the suffix.
+        // Example:
+        //    "FooEntity" becomes "Foo"
+        //    "Entity" remains as "Entity"
+        //    "Foo" remains as "Foo"
+        int substringLength = name.Length - EntitySuffix.Length;
+        if (substringLength > 0 && name.EndsWith(EntitySuffix, false, _culture))
         {
-            newName = name.Substring(0, name.Length - EntitySuffix.Length);
+            string newName = name.Substring(0, substringLength);
+            return newName;
         }
 
-        return newName;
+        // If we are here, is because we didn't modify the name.
+        return name;
     }
 }

--- a/EFCore.NamingConventions/NamingConventionsExtensions.cs
+++ b/EFCore.NamingConventions/NamingConventionsExtensions.cs
@@ -24,7 +24,7 @@ public static class NamingConventionsExtensions
     }
 
     public static DbContextOptionsBuilder<TContext> UseSnakeCaseNamingConvention<TContext>(
-        this DbContextOptionsBuilder<TContext> optionsBuilder , CultureInfo? culture = null)
+        this DbContextOptionsBuilder<TContext> optionsBuilder, CultureInfo? culture = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseSnakeCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
 
@@ -47,7 +47,7 @@ public static class NamingConventionsExtensions
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         CultureInfo? culture = null)
         where TContext : DbContext
-        => (DbContextOptionsBuilder<TContext>)UseLowerCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder ,culture);
+        => (DbContextOptionsBuilder<TContext>)UseLowerCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
 
     public static DbContextOptionsBuilder UseUpperCaseNamingConvention(
         this DbContextOptionsBuilder optionsBuilder,
@@ -111,4 +111,25 @@ public static class NamingConventionsExtensions
         CultureInfo? culture = null)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseCamelCaseNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
+
+    public static DbContextOptionsBuilder UseStripEntitySuffixNamingConvention(
+        this DbContextOptionsBuilder optionsBuilder,
+        CultureInfo? culture = null)
+    {
+        Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+
+        var extension = (optionsBuilder.Options.FindExtension<NamingConventionsOptionsExtension>()
+                ?? new NamingConventionsOptionsExtension())
+            .WithStripEntitySuffixNamingConvention(culture);
+
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        return optionsBuilder;
+    }
+
+    public static DbContextOptionsBuilder<TContext> UseStripEntitySuffixNamingConventionUseSuffixNamingConvention<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        CultureInfo? culture = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseStripEntitySuffixNamingConvention((DbContextOptionsBuilder)optionsBuilder, culture);
 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ SELECT c.id, c.full_name
 * UseCamelCaseNamingConvention: `FullName` becomes `fullName`
 * UseUpperCaseNamingConvention: `FullName` becomes `FULLNAME`
 * UseUpperSnakeCaseNamingConvention: `FullName` becomes `FULL_NAME`
+* UseStripEntitySuffixNamingConvention: `FullNameEntity` becomes `FullName`
 
 Have another naming convention in mind? Open an issue or even submit a PR - it's pretty easy to do!
 


### PR DESCRIPTION
fixes #324 

### Background
When working in service code, there are these 3 types of models:
- **Entities**: For persistence, used by Entity Framework.
- **Domain models**: Represent core logic, free of Entity Framework.
- **DTO** (Data Transfer Object): API contracts.

## Problem
It is common for these three kinds of models to share the same name and properties, so it becomes confusing to distinguish which one is what.

## Approach
A common best practice (this is not the only one) is using a suffix on the EF entity names to clarify what they are. For example:
`ProductEntity` and `PurchaseEntity`.
Although the "Entity" suffix is nice in the application source code, when mapping these entities to the database tables, the suffix "Entity" is unnecessary. 

| C# Class name    | Database table name |
| -------- | ------- |
| ProductEntity  | Product   |
| PurchaseEntity | Purchase |


## Solution

This PR adds a new naming convention extension method `UseStripEntitySuffixNamingConvention()` to remove the "Entity" suffix from the object model before mapping it to the database.
This allows you have c# classes named like `ProductEntity` while their database tables will be named like `Product`.
