### PR TITLE
fix: Handle JSON-mapped complex properties. Fixes #336

### DIFF
--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -693,7 +693,6 @@ public class NameRewritingConventionTest
 
         var entityType = model.FindEntityType(typeof(Waypoint))!;
         var complexType = entityType.FindComplexProperty("Location")!.ComplexType;
-        var longitude = complexType.FindProperty("Longitude")!;
 
         Assert.Equal("Location", complexType.GetContainerColumnName());
 

--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -687,6 +687,24 @@ public class NameRewritingConventionTest
     }
 
     [Fact]
+    public void Complex_property_ToJson()
+    {
+        var model = BuildModel(b => b.Entity<Waypoint>().ComplexProperty(w => w.Location).ToJson());
+
+        var entityType = model.FindEntityType(typeof(Waypoint))!;
+        var complexType = entityType.FindComplexProperty("Location")!.ComplexType;
+        var longitude = complexType.FindProperty("Longitude")!;
+
+        Assert.Equal("Location", complexType.GetContainerColumnName());
+
+        Assert.Equal("Longitude", complexType.FindProperty("Longitude")!.GetJsonPropertyName());
+        Assert.Equal("Latitude", complexType.FindProperty("Latitude")!.GetJsonPropertyName());
+
+        Assert.Null(complexType.FindProperty("Longitude")!.GetColumnName(StoreObjectIdentifier.Create(entityType, StoreObjectType.Table)!.Value));
+        Assert.Null(complexType.FindProperty("Latitude")!.GetColumnName(StoreObjectIdentifier.Create(entityType, StoreObjectType.Table)!.Value));
+    }
+
+    [Fact]
     public void Not_mapped_to_table()
     {
         var entityType = BuildEntityType(b => b.Entity<SampleEntity>().ToSqlQuery("SELECT foobar"));

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -463,6 +463,26 @@ public class NameRewritingConvention :
                     }
                 }
             }
+
+            foreach (var complexProperty in entityType.GetComplexProperties())
+            {
+                if (complexProperty.ComplexType is IComplexType complexType && complexType.IsMappedToJson())
+                {
+                    foreach (var propertyInComplexType in complexType.GetProperties())
+                    {
+                        if (propertyInComplexType is IConventionProperty conventionProperty)
+                        {
+                            var configurationSource = conventionProperty.GetColumnNameConfigurationSource();
+
+                            if (configurationSource == ConfigurationSource.Convention)
+                            {
+                                // JSON properties are not relational columns, so we overwrite the column name that was set previously.
+                                conventionProperty.SetColumnName(null);
+                            }
+                        }
+                    }
+                }
+            }  
         }
     }
 


### PR DESCRIPTION
Resolved an issue where _EFCore.NamingConventions_ incorrectly assigned a column name to a `ComplexProperty` stored as JSON, which caused EF Core to throw an exception.

When an entity has complex properties that are mapped to JSON, the code will detect them and null the Column Name set by `RewriteColumnName`. 

I initially attempted to implement the fix earlier in the conventions pipeline, specifically within `RewriteColumnName`, trying to prevent the property from being set in the first place. This approach was not successful because I couldn't reliably determine if the complex property was stored as JSON or not as this stage. Further details on the first attempt can be found in the [issue](https://github.com/efcore/EFCore.NamingConventions/issues/336).
