### PR TITLE
Update to .Net 10 GA

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,22 +1,22 @@
 <Project>
   <PropertyGroup>
-    <EFCoreVersion>[10.0.100-rc.2.25502.107,11.0.0)</EFCoreVersion>
-    <MicrosoftExtensionsVersion>10.0.100-rc.2.25502.107</MicrosoftExtensionsVersion>
+    <EFCoreVersion>[10.0.0,11.0.0)</EFCoreVersion>
+    <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0-rc.2.25502.107" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- Test -->
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0-rc.2.25502.107" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
 </Project>

--- a/EFCore.NamingConventions.Test/IntegrationTest.cs
+++ b/EFCore.NamingConventions.Test/IntegrationTest.cs
@@ -72,12 +72,12 @@ namespace EFCore.NamingConventions.Test
         public class Blog
         {
             public int Id { get; set; }
-            public string BlogProperty { get; set; }
+            public string BlogProperty { get; set; } = null!;
         }
 
         public class SpecialBlog : Blog
         {
-            public string SpecialBlogProperty { get; set; }
+            public string SpecialBlogProperty { get; set; } = null!;
         }
 
         public class BlogContext : DbContext

--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -865,14 +865,14 @@ public class NameRewritingConventionTest
     public class ReferenceNavigationPrincipal
     {
         public int Id { get; set; }
-        public ReferenceNavigationDependent Dependent { get; set; }
+        public ReferenceNavigationDependent Dependent { get; set; } = null!;
     }
 
     public class ReferenceNavigationDependent
     {
         public int Id { get; set; }
         public int PrincipalId { get; set; }
-        public ReferenceNavigationPrincipal Principal { get; set; }
+        public ReferenceNavigationPrincipal Principal { get; set; } = null!;
     }
 
     public class Board

--- a/EFCore.NamingConventions/EFCore.NamingConventions.csproj
+++ b/EFCore.NamingConventions/EFCore.NamingConventions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <VersionPrefix>10.0.0-rc.2</VersionPrefix>
+    <VersionPrefix>10.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../EFCore.NamingConventions.snk</AssemblyOriginatorKeyFile>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.2.25502.107",
+    "version": "10.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Changes in this PR:
- Changed the version to .Net 10 GA
- Changed `<PackageVersion />` to use the variables in the property group (NuGet messed this up on my last PR, sorry for that.)
- Removed a few CS8618 compiler warnings from the unit test by adding `= null!` to the property.
