### PR TITLE
Fix nested JSON owned entities causing ArgumentNullException in EF Core 10

### DIFF
--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -673,6 +673,50 @@ public class NameRewritingConventionTest
     }
 
     [Fact]
+    public void Owned_json_entity_with_nested_owned_collection_can_compile_query()
+    {
+        // This test reproduces the issue from PR #347 where nested JSON owned entities
+        // caused an ArgumentNullException during query compilation in EF Core 10.
+        // The bug was that nested entities within a JSON structure were incorrectly
+        // having container column names set on them, which caused EF Core's query
+        // compilation to fail with: ArgumentNullException: Value cannot be null. (Parameter 'key')
+
+        var optionsBuilder = new DbContextOptionsBuilder<JsonOwnedContext>();
+        SqlServerTestHelpers.Instance.UseProviderOptions(optionsBuilder);
+        optionsBuilder.UseSnakeCaseNamingConvention();
+
+        using var context = new JsonOwnedContext(optionsBuilder.Options);
+
+        // Without the fix, this would throw ArgumentNullException during query compilation.
+        // The fix ensures nested JSON entities don't get processed incorrectly.
+        var exception = Record.Exception(() =>
+        {
+            // The compilation happens when we create the query expression
+            _ = context.JsonOwners.ToQueryString();
+        });
+
+        // The query should compile successfully
+        Assert.Null(exception);
+
+        // Verify the model is configured correctly
+        var ownerEntityType = context.Model.FindEntityType(typeof(JsonOwner))!;
+        var detailsEntityType = context.Model.FindEntityType(typeof(JsonDetails))!;
+        var subDetailsEntityType = context.Model.FindEntityType(typeof(JsonSubDetail))!;
+
+        // Root entity should have snake_case table name (based on DbSet name)
+        Assert.Equal("json_owners", ownerEntityType.GetTableName());
+
+        // JSON root should have snake_case container column name
+        Assert.Equal("details", detailsEntityType.GetContainerColumnName());
+        Assert.Equal("json_owners", detailsEntityType.GetTableName());
+
+        // The nested JSON entity is part of the JSON structure
+        // It should have the same container column as the root JSON entity
+        Assert.Equal("details", subDetailsEntityType.GetContainerColumnName());
+        Assert.Equal("json_owners", subDetailsEntityType.GetTableName());
+    }
+
+    [Fact]
     public void Complex_property()
     {
         var model = BuildModel(b => b.Entity<Waypoint>().ComplexProperty(w => w.Location));
@@ -904,5 +948,38 @@ public class NameRewritingConventionTest
     {
         public int Id { get; }
         public required Board Board { get; set; }
+    }
+
+    public class JsonOwner
+    {
+        public int Id { get; set; }
+        public required JsonDetails Details { get; set; }
+    }
+
+    public class JsonDetails
+    {
+        public string? Name { get; set; }
+        public required List<JsonSubDetail> SubDetails { get; set; }
+    }
+
+    public class JsonSubDetail
+    {
+        public string? Value { get; set; }
+    }
+
+    public class JsonOwnedContext : DbContext
+    {
+        public JsonOwnedContext(DbContextOptions<JsonOwnedContext> options) : base(options) { }
+
+        public DbSet<JsonOwner> JsonOwners => Set<JsonOwner>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<JsonOwner>().OwnsOne(x => x.Details, details =>
+            {
+                details.ToJson();
+                details.OwnsMany(x => x.SubDetails);
+            });
+        }
     }
 }

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -168,19 +168,39 @@ public class NameRewritingConvention :
             // does nothing.
             ownedEntityType.FindPrimaryKey()?.Builder.HasNoAnnotation(RelationalAnnotationNames.Name);
 
-            if (ownedEntityType.IsMappedToJson())
-            {
-                ProcessJsonOwnedEntity(ownedEntityType, ownedEntityType.GetContainerColumnName());
+            // Check if this entity is part of a JSON structure - either directly mapped to JSON or nested within one.
+            var isNestedInJson = foreignKey.PrincipalEntityType.IsMappedToJson();
 
-                void ProcessJsonOwnedEntity(IConventionEntityType entityType, string? containerColumnName)
+            if (ownedEntityType.IsMappedToJson() || isNestedInJson)
+            {
+                if (isNestedInJson)
+                {
+                    // Nested JSON entities are part of the parent's JSON structure, not their own database column.
+                    // Clear any relational annotations that may have been set before the entity became part of JSON.
+                    ownedEntityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
+                    ownedEntityType.Builder.HasNoAnnotation(RelationalAnnotationNames.Schema);
+
+                    foreach (var property in ownedEntityType.GetProperties())
+                    {
+                        property.Builder.HasNoAnnotation(RelationalAnnotationNames.ColumnName);
+                    }
+
+                    context.StopProcessing();
+                    return;
+                }
+
+                if (ownedEntityType.GetContainerColumnName() is { } containerColumnName)
+                {
+                    // Rewrite container column name only on the root JSON entity.
+                    ownedEntityType.SetContainerColumnName(_namingNameRewriter.RewriteName(containerColumnName));
+                }
+
+                ProcessJsonOwnedEntity(ownedEntityType);
+
+                void ProcessJsonOwnedEntity(IConventionEntityType entityType)
                 {
                     entityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
                     entityType.Builder.HasNoAnnotation(RelationalAnnotationNames.Schema);
-
-                    if (containerColumnName is not null)
-                    {
-                        entityType.SetContainerColumnName(_namingNameRewriter.RewriteName(containerColumnName));
-                    }
 
                     // TODO: Note that we do not rewrite names of JSON properties (which aren't relational columns).
                     // TODO: We could introduce an option for doing so, though that's probably not usually what people want when doing JSON
@@ -194,7 +214,7 @@ public class NameRewritingConvention :
                     foreach (var navigation in entityType.GetNavigations()
                                  .Where(n => n is { IsOnDependent: false, ForeignKey.IsOwnership: true }))
                     {
-                        ProcessJsonOwnedEntity(navigation.TargetEntityType, containerColumnName);
+                        ProcessJsonOwnedEntity(navigation.TargetEntityType);
                     }
                 }
             }

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -169,26 +169,24 @@ public class NameRewritingConvention :
             ownedEntityType.FindPrimaryKey()?.Builder.HasNoAnnotation(RelationalAnnotationNames.Name);
 
             // Check if this entity is part of a JSON structure - either directly mapped to JSON or nested within one.
-            var isNestedInJson = foreignKey.PrincipalEntityType.IsMappedToJson();
-
-            if (ownedEntityType.IsMappedToJson() || isNestedInJson)
+            if (foreignKey.PrincipalEntityType.IsMappedToJson())
             {
-                if (isNestedInJson)
+                // Nested JSON entities are part of the parent's JSON structure, not their own database column.
+                // Clear any relational annotations that may have been set before the entity became part of JSON.
+                ownedEntityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
+                ownedEntityType.Builder.HasNoAnnotation(RelationalAnnotationNames.Schema);
+
+                foreach (var property in ownedEntityType.GetProperties())
                 {
-                    // Nested JSON entities are part of the parent's JSON structure, not their own database column.
-                    // Clear any relational annotations that may have been set before the entity became part of JSON.
-                    ownedEntityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
-                    ownedEntityType.Builder.HasNoAnnotation(RelationalAnnotationNames.Schema);
-
-                    foreach (var property in ownedEntityType.GetProperties())
-                    {
-                        property.Builder.HasNoAnnotation(RelationalAnnotationNames.ColumnName);
-                    }
-
-                    context.StopProcessing();
-                    return;
+                    property.Builder.HasNoAnnotation(RelationalAnnotationNames.ColumnName);
                 }
 
+                context.StopProcessing();
+                return;
+            }
+
+            if (ownedEntityType.IsMappedToJson())
+            {
                 if (ownedEntityType.GetContainerColumnName() is { } containerColumnName)
                 {
                     // Rewrite container column name only on the root JSON entity.


### PR DESCRIPTION
### Problem

When using naming conventions with JSON-mapped owned entities that have nested owned collections, an `ArgumentNullException` is thrown during query compilation:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at Microsoft.EntityFrameworkCore.Query.RelationalShapedQueryCompilingExpressionVisitor
      .ShaperProcessingExpressionVisitor.CreateJsonShapers(...)
```

This occurs when there are relations/children off of a entity marked with `ToJson()`

For example:

```csharp
entity.OwnsOne(x => x.Details, details =>
{
    details.ToJson();
    details.OwnsMany(x => x.SubDetails); // This is currently problematic
});
```

### Root Cause

The `ProcessJsonOwnedEntity` method was passing the parent's `containerColumnName` to all nested entities and calling `SetContainerColumnName()` on them. Nested JSON entities shouldn't have their own container column - they're part of the parent's JSON structure, not separate database columns.

When nested entities are off of an entity that has `ToJson()` called, they weren't being recognized as part of the JSON structure and were incorrectly processed.

### Fix

1. Detect when an owned entity is nested within an already JSON-mapped parent via `foreignKey.PrincipalEntityType.IsMappedToJson()`

2. Handle nested JSON entities by clearing relational annotations and returning early - they don't need container column names

3. Only rewrite the container column name on the root JSON entity

Fixes #346
