### PR TITLE
Avoid duplicate constraint names with entity splitting

### DIFF
--- a/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
+++ b/EFCore.NamingConventions.Test/NameRewritingConventionTest.cs
@@ -787,6 +787,69 @@ public class NameRewritingConventionTest
         Assert.Equal("fk_card_board_board_id", entityType.GetForeignKeys().Single().GetConstraintName());
     }
 
+    [Fact] // #314
+    public void Entity_splitting_primary_key_constraint_names_are_distinct_per_table()
+    {
+        var entityType = BuildEntityType(b => b.Entity<SplitEntity>(
+            e => e.SplitToTable(
+                "SplitEntityDetails", tb =>
+                {
+                    tb.Property(s => s.SplitProperty);
+                })));
+
+        var primaryKey = entityType.FindPrimaryKey()!;
+
+        // The primary key constraint exists in the main table and in every fragment table, but its
+        // name annotation is global to the key - a single rewritten name would produce duplicate
+        // constraint names across the tables. The convention leaves EF's per-table defaults in
+        // place instead, as it already does for TPT hierarchies.
+        Assert.Equal("PK_split_entity", primaryKey.GetName(StoreObjectIdentifier.Table("split_entity")));
+        Assert.Equal("PK_SplitEntityDetails", primaryKey.GetName(StoreObjectIdentifier.Table("SplitEntityDetails")));
+    }
+
+    [Fact] // #314
+    public void Entity_splitting_linking_foreign_key_constraint_names_are_distinct_per_table()
+    {
+        var entityType = BuildEntityType(b => b.Entity<SplitEntity>(
+            e => e.SplitToTable(
+                "SplitEntityDetails", tb =>
+                {
+                    tb.Property(s => s.SplitProperty);
+                })));
+
+        // The row-internal foreign key linking each fragment table back to the main table is also a
+        // single model object whose name annotation is global - and its default name is derived from
+        // the entity's main table on both sides, so the rewritten name never references the fragment
+        // table and collides when there is more than one fragment. EF's per-table defaults name each
+        // linking constraint for its own fragment table.
+        var linkingForeignKey = entityType.GetForeignKeys().Single(fk => fk.PrincipalEntityType == fk.DeclaringEntityType);
+
+        Assert.Equal(
+            "FK_SplitEntityDetails_split_entity_id",
+            linkingForeignKey.GetConstraintName(
+                StoreObjectIdentifier.Table("SplitEntityDetails"), StoreObjectIdentifier.Table("split_entity")));
+    }
+
+    [Fact]
+    public void Entity_splitting_does_not_rewrite_the_explicitly_configured_fragment_table_name()
+    {
+        var entityType = BuildEntityType(b => b.Entity<SplitEntity>(
+            e => e.SplitToTable(
+                "SplitEntityDetails", tb =>
+                {
+                    tb.Property(s => s.SplitProperty);
+                })));
+
+        // SplitToTable always takes an explicitly-specified table name, and explicitly-configured
+        // names are never rewritten.
+        var fragment = Assert.Single(entityType.GetMappingFragments());
+        Assert.Equal("SplitEntityDetails", fragment.StoreObject.Name);
+        Assert.Equal(
+            "split_property",
+            entityType.FindProperty(nameof(SplitEntity.SplitProperty))!
+                .GetColumnName(StoreObjectIdentifier.Table("SplitEntityDetails")));
+    }
+
     private static IEntityType BuildEntityType(Action<ModelBuilder> builderAction, CultureInfo? culture = null)
         => BuildModel(builderAction, culture).GetEntityTypes().Single();
 
@@ -936,6 +999,13 @@ public class NameRewritingConventionTest
         public int Id { get; set; }
         public int PrincipalId { get; set; }
         public required ReferenceNavigationPrincipal Principal { get; set; }
+    }
+
+    public class SplitEntity
+    {
+        public int Id { get; set; }
+        public string? MainProperty { get; set; }
+        public string? SplitProperty { get; set; }
     }
 
     public class Board

--- a/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
+++ b/EFCore.NamingConventions/Internal/NameRewritingConvention.cs
@@ -507,6 +507,29 @@ public class NameRewritingConvention :
                 }
             }
 
+            // With entity splitting, the primary key constraint exists in the main table and in every fragment table, but the key's name
+            // annotation is a single, global one - the name we rewrote in ProcessKeyAdded would be used for the constraint in every one of
+            // those tables, producing duplicate constraint names in the database (#314). The same applies to the row-internal foreign key
+            // linking each fragment table back to the main table: its default name is derived from the entity's main table on both sides,
+            // so the rewritten name never references the fragment table and collides when there's more than one fragment.
+            // EF doesn't yet support configuring different constraint names for the same key/foreign key across different tables
+            // (as with TPT, see the note in ProcessEntityTypeAnnotationChanged), so undo our rewriting and let EF's per-table default
+            // names apply.
+            if (entityType.GetMappingFragments(StoreObjectType.Table).Any()
+                && entityType.FindPrimaryKey() is { } primaryKey)
+            {
+                primaryKey.Builder.HasNoAnnotation(RelationalAnnotationNames.Name);
+
+                foreach (var foreignKey in entityType.GetDeclaredForeignKeys())
+                {
+                    if (foreignKey.PrincipalEntityType == entityType
+                        && foreignKey.Properties.SequenceEqual(primaryKey.Properties))
+                    {
+                        foreignKey.Builder.HasNoAnnotation(RelationalAnnotationNames.Name);
+                    }
+                }
+            }
+
             foreach (var property in entityType.GetProperties())
             {
                 var columnName = property.GetColumnName();


### PR DESCRIPTION
## The problem

With entity splitting (`SplitToTable`), the primary key constraint exists in the main table **and** in every fragment table, but a key's name annotation (`RelationalAnnotationNames.Name`) is a single global annotation — `RelationalKeyExtensions.GetName(storeObject)` returns the explicit annotation for fragment tables too. The name this convention rewrites in `ProcessKeyAdded` therefore lands on the PK constraint of **every** table the entity is split across, and PostgreSQL fails at migration time with `42P07: relation "pk_..." already exists` (PK constraint names are backed by schema-scoped relations). Without the naming convention, EF's per-table defaults (`PK_Table1` / `PK_Table2`) never collide.

The row-internal foreign key linking each fragment table back to the main table has the same shape: it is a single model-level FK whose no-arg default name derives from the entity's **main** table on both sides, so the rewritten global name never references the fragment table — and collides outright when there is more than one fragment (SQL Server constraint names are schema-scoped).

Fixes #314

## The fix

At model finalization, for fragment-bearing entities, remove the name annotations this convention previously set on the primary key and on the row-internal linking FK, letting EF's per-table default names apply — the same treatment `ProcessEntityTypeAnnotationChanged` already gives TPT hierarchies, and for the same underlying reason: EF has no per-store-object override for key/FK constraint names (verified against current `main`), so distinct-per-table rewritten names are not expressible today.

Explicitly-configured fragment table names were already correctly left alone (`SplitToTable` always takes an explicit name, and explicit configuration is never rewritten); a test now pins that behavior.

## Tests

- `Entity_splitting_primary_key_constraint_names_are_distinct_per_table` — the #314 repro
- `Entity_splitting_linking_foreign_key_constraint_names_are_distinct_per_table`
- `Entity_splitting_does_not_rewrite_the_explicitly_configured_fragment_table_name` — policy pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)